### PR TITLE
Set .NET 10 as default; add UseNet08 for .NET 8 builds

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -1,7 +1,7 @@
 #!/usr/bin/env pwsh
 param(
     [Parameter(Mandatory = $false)]
-    [switch]$UseNet10 = $false,
+    [switch]$UseNet08 = $false,
     
     [Parameter(Mandatory = $false)]
     [switch]$Test = $false,
@@ -29,15 +29,15 @@ Write-Host "Xcaciv.Loader Build Script"
 Write-Host "====================================================="
 if ($Publish) {
     Write-Host "Mode: Publish" -ForegroundColor Cyan
-    if ($UseNet10) {
-        Write-Host "Target Frameworks: .NET 8.0 and .NET 10.0" -ForegroundColor Cyan
+    if ($UseNet08) {
+        Write-Host "Target Frameworks: .NET 10.0 and .NET 8.0" -ForegroundColor Cyan
     } else {
-        Write-Host "Target Framework: .NET 8.0 only" -ForegroundColor Cyan
+        Write-Host "Target Framework: .NET 10.0 only" -ForegroundColor Cyan
     }
-} elseif ($UseNet10) {
-    Write-Host "Target Frameworks: .NET 8.0 and .NET 10.0"
+} elseif ($UseNet08) {
+    Write-Host "Target Frameworks: .NET 10.0 and .NET 8.0"
 } else {
-    Write-Host "Target Framework: .NET 8.0 only"
+    Write-Host "Target Framework: .NET 10.0 only"
 }
 Write-Host "Run Tests: $( if ($Test) { "Yes" } else { "No" } )"
 Write-Host "Local NuGet path: $LocalNugetPath"
@@ -50,8 +50,8 @@ Write-Host "====================================================="
 
 # Build
 Write-Host "Building solution..." -ForegroundColor Cyan
-if ($UseNet10) {
-    $buildCommand = "dotnet build --configuration Release /p:UseNet10=true"
+if ($UseNet08) {
+    $buildCommand = "dotnet build --configuration Release /p:UseNet08=true"
 } else {
     $buildCommand = "dotnet build --configuration Release"
 }
@@ -132,8 +132,8 @@ if ($Publish) {
 if ($Test) {
     Write-Host "Running tests..." -ForegroundColor Cyan
     $testCommand = "dotnet test --no-build --configuration Release"
-    if ($UseNet10) {
-        $testCommand += " /p:UseNet10=true"
+    if ($UseNet08) {
+        $testCommand += " /p:UseNet08=true"
     }
     Write-Host "Executing: $testCommand" -ForegroundColor Gray
     Invoke-Expression $testCommand

--- a/src/TestAssembly/zTestAssembly.csproj
+++ b/src/TestAssembly/zTestAssembly.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Default to .NET 8.0 for wider compatibility -->
-    <TargetFramework>net8.0</TargetFramework>
-    <!-- Define a property to conditionally switch to .NET 10 -->
-    <UseNet10 Condition="'$(UseNet10)' == ''">false</UseNet10>
-    <TargetFramework Condition="'$(UseNet10)' == 'true'">net10.0</TargetFramework>
+    <!-- Default to .NET 10.0 -->
+    <TargetFramework>net10.0</TargetFramework>
+    <!-- Define a property to conditionally switch to .NET 8 -->
+    <UseNet08 Condition="'$(UseNet08)' == ''">false</UseNet08>
+    <TargetFramework Condition="'$(UseNet08)' == 'true'">net8.0</TargetFramework>
     
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/src/Xcaciv.Loader/Xcaciv.Loader.csproj
+++ b/src/Xcaciv.Loader/Xcaciv.Loader.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Target Frameworks - Build for both .NET 8 and .NET 10 by default -->
-    <TargetFrameworks Condition="'$(UseNet10)' == 'true'">net8.0;net10.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(UseNet10)' != 'true'">net8.0</TargetFrameworks>
+    <!-- Target Frameworks - Build for both .NET 10 and .NET 8 when UseNet08 is true -->
+    <TargetFrameworks Condition="'$(UseNet08)' == 'true'">net10.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(UseNet08)' != 'true'">net10.0</TargetFrameworks>
     
     <!-- Version Information -->
     <Version>2.1.1</Version>
@@ -21,12 +21,12 @@
     <!-- Package Metadata -->
     <PackageId>Xcaciv.Loader</PackageId>
     <Title>Xcaciv.Loader - Secure Dynamic Assembly Loading</Title>
-    <Description>Secure, modern .NET library for runtime loading of types from external assemblies. Features instance-based security policies, optional cryptographic integrity verification, comprehensive audit trail events, and SSEM-compliant architecture. Perfect for plugin systems and modular applications.</Description>
+    <Description>Secure, modern .NET library for runtime loading of types from external assemblies. Features instance-based security policies, optional cryptographic integrity verification, comprehensive audit trail events, and SSEM-compliant architecture. Perfect for plugin systems and modular applications. Supports .NET 10 and .NET 8.</Description>
     <Authors>Alton Crossley</Authors>
     <Copyright>Copyright © 2021-2025 Alton Crossley</Copyright>
     
     <!-- Package Classification -->
-    <PackageTags>assembly;loader;plugin;dynamic;security;modular;plugins;addins;extensions;reflection;isolation;unloading;integrity;verification;SSEM</PackageTags>
+    <PackageTags>assembly;loader;plugin;dynamic;security;modular;plugins;addins;extensions;reflection;isolation;unloading;integrity;verification;SSEM;net10;net8</PackageTags>
     <PackageProjectUrl>https://github.com/Xcaciv/Xcaciv.Loader</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Xcaciv/Xcaciv.Loader</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
@@ -35,14 +35,19 @@
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
     
     <!-- Release Notes -->
-    <PackageReleaseNotes>Major v2.0 release with breaking changes and significant new features:
+    <PackageReleaseNotes>Major v2.1 release with .NET 10 support and continued .NET 8 compatibility:
 
-BREAKING CHANGES:
+NEW IN v2.1:
+✅ Default target: .NET 10 (with optional .NET 8 support)
+✅ Multi-targeting support for both .NET 10 and .NET 8 in NuGet package
+✅ Simplified build process with UseNet08 flag
+
+BREAKING CHANGES FROM v2.0:
 - Security configuration now instance-based (use AssemblySecurityPolicy parameter)
 - Deprecated static SetStrictDirectoryRestriction() - will be removed in v3.0
 - GetLoadedTypes&lt;T&gt;() moved to AssemblyScanner class
 
-NEW FEATURES:
+FEATURES:
 ✅ Instance-based security policies (Default/Strict/Custom)
 ✅ Optional assembly integrity verification with SHA256/384/512
 ✅ Comprehensive event system for audit trail and monitoring

--- a/src/Xcaciv.LoaderTests/EventTests.cs
+++ b/src/Xcaciv.LoaderTests/EventTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Reflection;
 using System.Security;
 using Xunit;
 using Xunit.Abstractions;
@@ -21,13 +22,40 @@ public class EventTests
     {
         this.output = output;
         
+        // Detect the target framework at runtime
+        var targetFramework = GetTargetFramework();
+        output.WriteLine($"Tests running on {targetFramework}");
+
 #if DEBUG
-        this.simpleDllPath = @"..\..\..\..\TestAssembly\bin\Debug\net8.0\zTestAssembly.dll";
-        this.dependentDllPath = @"..\..\..\..\zTestDependentAssembly\bin\Debug\net8.0\zTestDependentAssembly.dll";
+        this.simpleDllPath = $@"..\..\..\..\TestAssembly\bin\Debug\{targetFramework}\zTestAssembly.dll";
+        this.dependentDllPath = $@"..\..\..\..\zTestDependentAssembly\bin\Debug\{targetFramework}\zTestDependentAssembly.dll";
 #else
-        this.simpleDllPath = @"..\..\..\..\TestAssembly\bin\Release\net8.0\zTestAssembly.dll";
-        this.dependentDllPath = @"..\..\..\..\zTestDependentAssembly\bin\Release\net8.0\zTestDependentAssembly.dll";
+        this.simpleDllPath = $@"..\..\..\..\TestAssembly\bin\Release\{targetFramework}\zTestAssembly.dll";
+        this.dependentDllPath = $@"..\..\..\..\zTestDependentAssembly\bin\Release\{targetFramework}\zTestDependentAssembly.dll";
 #endif
+    }
+
+    /// <summary>
+    /// Detects the target framework of the current assembly (net8.0, net10.0, etc.)
+    /// </summary>
+    private static string GetTargetFramework()
+    {
+        var targetFrameworkAttribute = Assembly.GetExecutingAssembly()
+            .GetCustomAttribute<System.Runtime.Versioning.TargetFrameworkAttribute>();
+        
+        if (targetFrameworkAttribute != null)
+        {
+            var frameworkName = targetFrameworkAttribute.FrameworkName;
+            // Format: ".NETCoreApp,Version=v10.0" -> "net10.0"
+            if (frameworkName.Contains("Version=v"))
+            {
+                var version = frameworkName.Split("Version=v")[1];
+                return $"net{version}";
+            }
+        }
+        
+        // Fallback to net10.0 if detection fails
+        return "net10.0";
     }
 
     #region AssemblyLoaded Event Tests

--- a/src/Xcaciv.LoaderTests/Xcaciv.LoaderTests.csproj
+++ b/src/Xcaciv.LoaderTests/Xcaciv.LoaderTests.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- Default to .NET 8.0 for wider compatibility -->
-    <TargetFramework>net8.0</TargetFramework>
-    <!-- Define a property to conditionally switch to .NET 10 -->
-    <UseNet10 Condition="'$(UseNet10)' == ''">false</UseNet10>
-    <TargetFramework Condition="'$(UseNet10)' == 'true'">net10.0</TargetFramework>
+    <!-- Default to .NET 10.0 -->
+    <TargetFramework>net10.0</TargetFramework>
+    <!-- Define a property to conditionally switch to .NET 8 -->
+    <UseNet08 Condition="'$(UseNet08)' == ''">false</UseNet08>
+    <TargetFramework Condition="'$(UseNet08)' == 'true'">net8.0</TargetFramework>
     
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/src/zTestDependentAssembly/zTestDependentAssembly.csproj
+++ b/src/zTestDependentAssembly/zTestDependentAssembly.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Default to .NET 8.0 for wider compatibility -->
-    <TargetFramework>net8.0</TargetFramework>
-    <!-- Define a property to conditionally switch to .NET 10 -->
-    <UseNet10 Condition="'$(UseNet10)' == ''">false</UseNet10>
-    <TargetFramework Condition="'$(UseNet10)' == 'true'">net10.0</TargetFramework>
+    <!-- Default to .NET 10.0 -->
+    <TargetFramework>net10.0</TargetFramework>
+    <!-- Define a property to conditionally switch to .NET 8 -->
+    <UseNet08 Condition="'$(UseNet08)' == ''">false</UseNet08>
+    <TargetFramework Condition="'$(UseNet08)' == 'true'">net8.0</TargetFramework>
     
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/src/zTestInterfaces/zTestInterfaces.csproj
+++ b/src/zTestInterfaces/zTestInterfaces.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Default to .NET 8.0 for wider compatibility -->
-    <TargetFramework>net8.0</TargetFramework>
-    <!-- Define a property to conditionally switch to .NET 10 -->
-    <UseNet10 Condition="'$(UseNet10)' == ''">false</UseNet10>
-    <TargetFramework Condition="'$(UseNet10)' == 'true'">net10.0</TargetFramework>
+    <!-- Default to .NET 10.0 -->
+    <TargetFramework>net10.0</TargetFramework>
+    <!-- Define a property to conditionally switch to .NET 8 -->
+    <UseNet08 Condition="'$(UseNet08)' == ''">false</UseNet08>
+    <TargetFramework Condition="'$(UseNet08)' == 'true'">net8.0</TargetFramework>
     
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/src/zTestLinqExpressions/zTestLinqExpressions.csproj
+++ b/src/zTestLinqExpressions/zTestLinqExpressions.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Default to .NET 8.0 for wider compatibility -->
-    <TargetFramework>net8.0</TargetFramework>
-    <!-- Define a property to conditionally switch to .NET 10 -->
-    <UseNet10 Condition="'$(UseNet10)' == ''">false</UseNet10>
-    <TargetFramework Condition="'$(UseNet10)' == 'true'">net10.0</TargetFramework>
+    <!-- Default to .NET 10.0 -->
+    <TargetFramework>net10.0</TargetFramework>
+    <!-- Define a property to conditionally switch to .NET 8 -->
+    <UseNet08 Condition="'$(UseNet08)' == ''">false</UseNet08>
+    <TargetFramework Condition="'$(UseNet08)' == 'true'">net8.0</TargetFramework>
     
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/src/zTestRiskyAssembly/zTestRiskyAssembly.csproj
+++ b/src/zTestRiskyAssembly/zTestRiskyAssembly.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Default to .NET 8.0 for wider compatibility -->
-    <TargetFramework>net8.0</TargetFramework>
-    <!-- Define a property to conditionally switch to .NET 10 -->
-    <UseNet10 Condition="'$(UseNet10)' == ''">false</UseNet10>
-    <TargetFramework Condition="'$(UseNet10)' == 'true'">net10.0</TargetFramework>
+    <!-- Default to .NET 10.0 -->
+    <TargetFramework>net10.0</TargetFramework>
+    <!-- Define a property to conditionally switch to .NET 8 -->
+    <UseNet08 Condition="'$(UseNet08)' == ''">false</UseNet08>
+    <TargetFramework Condition="'$(UseNet08)' == 'true'">net8.0</TargetFramework>
     
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
Set .NET 10 as default; add UseNet08 for .NET 8 builds

Switch default target framework to .NET 10 in all projects. Replace UseNet10 with UseNet08 flag for optional .NET 8.0 support in build.ps1 and .csproj files. Update build logic, output messages, and package metadata to reflect new default and multi-targeting. This streamlines the build process while retaining .NET 8 compatibility when needed.